### PR TITLE
タスク完了ステータス更新処理関連のバリデーション追加

### DIFF
--- a/src/components/TaskClear.tsx
+++ b/src/components/TaskClear.tsx
@@ -4,7 +4,7 @@ import { clearTaskList } from '../stores/TaskListSlice'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faTrashCan } from '@fortawesome/free-solid-svg-icons'
 
-const TaskClear: FC<{}> = () => {
+const TaskClear: FC = () => {
   const dispatch = useDispatch()
 
   return (

--- a/src/components/TaskListTask.tsx
+++ b/src/components/TaskListTask.tsx
@@ -13,6 +13,8 @@ import { setParentTaskId } from '../stores/TaskAddSlice'
 import type { Task } from '../types/Task'
 import TaskList from './TaskList'
 import TaskEdit from './TaskEdit'
+import { validateClosingTask, validateReopeningTask } from '../functions/Task'
+import { showNotification } from '@mantine/notifications'
 
 interface TaskListTaskProps {
   depth: Number
@@ -42,14 +44,35 @@ const TaskListTask: FC<TaskListTaskProps> = (props) => {
   const handleOnStatus = (taskId: string, status: boolean) => {
     const deepCopy = taskListSelector.taskList.map((todo) => ({ ...todo }))
 
+    //validation
+    const res = status
+      ? validateReopeningTask(props.task, deepCopy)
+      : validateClosingTask(props.task, deepCopy)
+
+    //notify if validation is successful
+    if (!res.success) {
+      showNotification({
+        title: 'ステータスの更新に失敗しました',
+        message: res.message,
+        autoClose: 5000,
+        color: 'red',
+      })
+      return
+    }
+
+    //update status if validation is successful
     const newTodos = deepCopy.map((todo) => {
       if (todo.taskId === taskId) {
         todo.status = !status
       }
       return todo
     })
-
     dispatch(setTaskList(newTodos))
+    showNotification({
+      message: 'ステータスの更新に成功しました',
+      autoClose: 5000,
+      color: 'green',
+    })
   }
 
   return (

--- a/src/functions/Task.ts
+++ b/src/functions/Task.ts
@@ -1,4 +1,12 @@
-import type { Task } from '../types/Task'
+import type {
+  ChangeStatusResponse,
+  CheckTasksChangingStatus,
+  GetAllChildTasksArgs,
+  GetAllParentTasksArgs,
+  GetParentTaskArgs,
+  GetTasksOneLevelDownArgs,
+  Task,
+} from '../types/Task'
 
 export function validateTask(task: Task): string {
   if (task.taskId.length !== 26) {
@@ -16,6 +24,106 @@ export function validateTask(task: Task): string {
     return '締め切り日は未来の日付にしてください'
   }
   return ''
+}
+
+// Get child tasks one level down when changing status
+function getTasksOneLevelDown(args: GetTasksOneLevelDownArgs): Task[] {
+  const { task, tasksInState } = args
+  return tasksInState.filter((t) => t.parentTaskId === task.taskId)
+}
+
+function getAllChildTasks(args: GetAllChildTasksArgs): Task[] {
+  const childTasks = getTasksOneLevelDown(args)
+  if (childTasks.length === 0) {
+    return []
+  }
+  return childTasks.reduce((acc: Task[], t) => {
+    return acc.concat(
+      getTasksOneLevelDown({
+        task: t,
+        tasksInState: args.tasksInState,
+      } as GetTasksOneLevelDownArgs)
+    )
+  }, childTasks)
+}
+
+function getParentTask(args: GetParentTaskArgs): Task | undefined {
+  if (args.task.parentTaskId === null) {
+    return undefined
+  }
+  return args.tasksInState.find((t) => t.taskId === args.task.parentTaskId)
+}
+
+function getAllParentTasks(args: GetAllParentTasksArgs): Task[] {
+  const parentTasks = [] as Task[]
+  let currentArgs = args
+  let parentTask: Task | undefined = getParentTask(currentArgs)
+
+  while (parentTask !== undefined) {
+    parentTasks.push(parentTask)
+    currentArgs = {
+      task: parentTask,
+      tasksInState: args.tasksInState,
+    }
+    parentTask = getParentTask(currentArgs)
+  }
+
+  return parentTasks
+}
+
+// Check for problematic tasks in child tasks one level down when changing status
+function areChildTasksOk(args: CheckTasksChangingStatus): boolean {
+  const { tasks } = args
+  return tasks.filter((t) => t.status === false).length === 0
+}
+
+function areParentTasksOk(args: CheckTasksChangingStatus): boolean {
+  const { tasks } = args
+  return tasks.filter((t) => t.status === true).length === 0
+}
+
+export function validateClosingTask(
+  task: Task,
+  tasksInState: Task[]
+): ChangeStatusResponse {
+  const tasks = getAllChildTasks({
+    task,
+    tasksInState,
+  } as GetAllChildTasksArgs)
+  if (!areChildTasksOk({ tasks } as CheckTasksChangingStatus)) {
+    return {
+      success: false,
+      errType: 'CHILD_TASK_INCOMPLETE_ERROR',
+      message: '子タスクが未完了です',
+    }
+  }
+  return {
+    success: true,
+    errType: undefined,
+    message: undefined,
+  }
+}
+
+export function validateReopeningTask(
+  task: Task,
+  tasksInState: Task[]
+): ChangeStatusResponse {
+  const tasks = getAllParentTasks({
+    task,
+    tasksInState,
+  } as GetAllParentTasksArgs)
+  if (!areParentTasksOk({ tasks } as CheckTasksChangingStatus)) {
+    return {
+      success: false,
+      errType: 'PARENT_TASKS_CLOSED',
+      message: '親タスクが完了しています',
+    }
+  }
+  return {
+    success: true,
+    errType: undefined,
+    message: undefined,
+  }
 }
 
 export const DateFormat = 'YYYY-MM-DD'

--- a/src/types/Task.d.ts
+++ b/src/types/Task.d.ts
@@ -3,14 +3,55 @@ type ParentTaskIdType = string | null
 
 type ChangeStatus = boolean
 
+interface GetAllChildTasksArgs {
+  task: Task
+  tasksInState: Task[]
+}
+
+interface GetAllParentTasksArgs {
+  task: Task
+  tasksInState: Task[]
+}
+
+interface GetParentTaskArgs {
+  task: Task
+  tasksInState: Task[]
+}
+
+interface GetTasksOneLevelDownArgs {
+  task: Task
+  tasksInState: Task[]
+}
+
+interface CheckTasksChangingStatus {
+  tasks: Task[]
+}
+
+interface ChangeStatusResponse {
+  success: boolean
+  errType: 'CHILD_TASK_INCOMPLETE_ERROR' | 'PARENT_TASKS_CLOSED' | undefined
+  message: string | undefined
+}
+
 interface Task {
   taskId: string // ulid
   parentTaskId: ParentTaskIdType
   taskName: string
-  dueDate: string // YYYY-MM-DD でもDate型かdayjs系の型に変えたい...
+  dueDate: string
   status: ChangeStatus
 }
 
 type DeleteTask = (taskId: string) => void
 
-export { ParentTaskIdType, Task, DeleteTask, ChangeStatus }
+export {
+  ParentTaskIdType,
+  Task,
+  DeleteTask,
+  ChangeStatus,
+  ChangeStatusResponse,
+  CheckTasksChangingStatus,
+  GetTasksOneLevelDownArgs,
+  GetAllChildTasksArgs,
+  GetAllParentTasksArgs,
+  GetParentTaskArgs,
+}


### PR DESCRIPTION
close #24 

以下のバリデーションルールを追加

- 子タスクが全て完了していないと親タスクは完了できない
- 親タスクが全て未完了でないと子タスクは未完了にできない