### PR TITLE
feat:親子タスクdueDateのバリデーション

### DIFF
--- a/src/components/TaskListTask.tsx
+++ b/src/components/TaskListTask.tsx
@@ -51,8 +51,8 @@ const TaskListTask: FC<TaskListTaskProps> = (props) => {
 
     //validation
     const res = status
-      ? validateReopeningTask(props.task, deepCopy)
-      : validateClosingTask(props.task, deepCopy)
+      ? validateReopeningTask(props.task)
+      : validateClosingTask(props.task)
 
     //notify if validation is successful
     if (!res.success) {

--- a/src/functions/Task.ts
+++ b/src/functions/Task.ts
@@ -38,8 +38,8 @@ export function validateTask(task: Task): string {
   })
   if (parentTasks.length !== 0) {
     const parentTasksDueDate = parentTasks.map((t) => dayjs(t.dueDate))
-    if (parentTasksDueDate.some((d) => !isAfterOrSameByDate(d, dueDate))) {
-      return 'タスクの期限は全ての親タスクよりも後でなければなりません'
+    if (parentTasksDueDate.some((d) => !isBeforeOrSameByDate(d, dueDate))) {
+      return 'タスクの期限は全ての親タスク以前でなければなりません'
     }
   }
   //check if all child tasks dueDate is after dueDate of current task
@@ -48,8 +48,8 @@ export function validateTask(task: Task): string {
   })
   if (childTasks.length !== 0) {
     const childTasksDueDate = childTasks.map((t) => dayjs(t.dueDate))
-    if (childTasksDueDate.some((d) => !isBeforeOrSameByDate(d, dueDate))) {
-      return 'タスクの期限は全ての子タスクよりも前でなければなりません'
+    if (childTasksDueDate.some((d) => !isAfterOrSameByDate(d, dueDate))) {
+      return 'タスクの期限は全ての子タスク以後でなければなりません'
     }
   }
 

--- a/src/functions/helpers/Dayjs.ts
+++ b/src/functions/helpers/Dayjs.ts
@@ -1,0 +1,81 @@
+import dayjs from 'dayjs'
+
+export function isBeforeOrSameByDate(
+  dayjsSrc: dayjs.Dayjs,
+  dayjsDest: dayjs.Dayjs
+): boolean {
+  const [srcYear, srcMonth, srcDate] = [
+    dayjsSrc.year(),
+    dayjsSrc.month(),
+    dayjsSrc.date(),
+  ]
+  const [destYear, destMonth, destDate] = [
+    dayjsDest.year(),
+    dayjsDest.month(),
+    dayjsDest.date(),
+  ]
+  switch (true) {
+    case srcYear > destYear:
+      return true
+    case srcYear < destYear:
+      return false
+    case srcYear === destYear:
+      switch (true) {
+        case srcMonth > destMonth:
+          return true
+        case srcMonth < destMonth:
+          return false
+        case srcMonth === destMonth:
+          switch (true) {
+            case srcDate > destDate:
+              return true
+            case srcDate < destDate:
+              return false
+            case srcDate === destDate:
+              return true
+          }
+      }
+  }
+  //unreachable
+  throw new Error('isBeforeOrSameByDate: invalid date')
+}
+
+export function isAfterOrSameByDate(
+  dayjsSrc: dayjs.Dayjs,
+  dayjsDest: dayjs.Dayjs
+): boolean {
+  const [srcYear, srcMonth, srcDate] = [
+    dayjsSrc.year(),
+    dayjsSrc.month(),
+    dayjsSrc.date(),
+  ]
+  const [destYear, destMonth, destDate] = [
+    dayjsDest.year(),
+    dayjsDest.month(),
+    dayjsDest.date(),
+  ]
+  switch (true) {
+    case srcYear < destYear:
+      return true
+    case srcYear > destYear:
+      return false
+    case srcYear === destYear:
+      switch (true) {
+        case srcMonth < destMonth:
+          return true
+        case srcMonth > destMonth:
+          return false
+        case srcMonth === destMonth:
+          switch (true) {
+            case srcDate < destDate:
+              return true
+            case srcDate > destDate:
+              return false
+            case srcDate === destDate:
+              return true
+          }
+      }
+  }
+  //unreachable
+  throw new Error('isAfterOrSameByDate: invalid date')
+}

--- a/src/types/Task.ts
+++ b/src/types/Task.ts
@@ -5,22 +5,18 @@ type ChangeStatus = boolean
 
 interface GetAllChildTasksArgs {
   task: Task
-  tasksInState: Task[]
 }
 
 interface GetAllParentTasksArgs {
   task: Task
-  tasksInState: Task[]
 }
 
 interface GetParentTaskArgs {
   task: Task
-  tasksInState: Task[]
 }
 
 interface GetTasksOneLevelDownArgs {
   task: Task
-  tasksInState: Task[]
 }
 
 interface CheckTasksChangingStatus {


### PR DESCRIPTION
親子タスク間の締め切り日のバリデーションを追加したものです

- 日付だけを見て2つのdayjsインスタンスの前後関係を判定する関数をhelpersディレクトリに追加しました
- ~バリデーションルールとしては「あるタスクのdueDateは親タスクのdueDateと同じかそれ以降でなくなてはならない」「あるタスクのdueDateは子タスクのdueDateと同じかそれ以前でなくてはならない」を実装しています~
- バリデーションルールとしては「あるタスクのdueDateは親タスクのdueDateと同じかそれ以前でなくなてはならない」「あるタスクのdueDateは子タスクのdueDateと同じかそれ以降でなくてはならない」を実装しています
- 現在のタスク状態をstateではなくlocalstorageから取得するように統一しました

close #33 